### PR TITLE
Update repo URLs

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -9,6 +9,6 @@ kind: theme
 labextension_name: jupyterlab-day
 project_short_description: Dark theme for JupyterLab
 python_name: jupyterlab_day
-repository: https://github.com/martinRenou/jupyterlab-day.git
+repository: https://github.com/jupyterlab-contrib/jupyterlab-day.git
 test: false
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyterlab-day
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/martinRenou/jupyterlab-day/main?urlpath=lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab-contrib/jupyterlab-day/main?urlpath=lab)
 
 JupyterLab light theme inspired by the Github light theme
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
         "jupyterlab",
         "jupyterlab-extension"
     ],
-    "homepage": "https://github.com/martinRenou/jupyterlab-day",
+    "homepage": "https://github.com/jupyterlab-contrib/jupyterlab-day",
     "bugs": {
-        "url": "https://github.com/martinRenou/jupyterlab-day/issues"
+        "url": "https://github.com/jupyterlab-contrib/jupyterlab-day/issues"
     },
     "license": "BSD-3-Clause",
     "author": {
@@ -24,7 +24,7 @@
     "types": "lib/index.d.ts",
     "repository": {
         "type": "git",
-        "url": "https://github.com/martinRenou/jupyterlab-day.git"
+        "url": "https://github.com/jupyterlab-contrib/jupyterlab-day.git"
     },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",


### PR DESCRIPTION
Follow-up to the move, should fix the failing CI check:

![image](https://github.com/user-attachments/assets/d08ef8ce-ff9f-433f-bc29-c5e76dd4a33c)
